### PR TITLE
Add custom album cover

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ novaGallery is a beautiful php image gallery with the focus on your images, trim
 * **Albums**: Directories are rendered as albums
 * **Sub-Albums**: Can be used for more detailed organisation
 * **Preview images** for albums: Automatically generate an album preview image
+* **Custom album covers**: Use your own image as album cover (placed in album directory)
 * **Photo overview**: All photos are displayed sorted by creation date or name
 * **Lightbox**: View your photos in large format, hiding everything that is distracting
 * **Slideshow**: All photos in an album, can be displayed and presented via click (or keyboard) in the lightbox view
@@ -62,6 +63,17 @@ novaGallery is a beautiful php image gallery with the focus on your images, trim
 * Every folder in galleries is a gallery
 * In `config/site.php` you can change some basic informations, image sizes and other settings
 * That's it :-)
+
+### Custom Album Covers
+
+You can customize the cover image for each album by placing a file named `cover.jpg` (or your custom filename) in the album directory. This image will be used as the album cover instead of the automatically generated preview.
+
+To use a custom cover image:
+1. Place your cover image file in the album directory
+2. The image should be in JPEG, PNG, GIF, or WebP format
+3. The filename must be `cover.jpg` (by default) or your custom filename configured in `coverFileName`
+
+Custom cover images are automatically excluded from the album's image list.
 
 #### Configuration for Installation in Subdir
 
@@ -155,6 +167,7 @@ novaGallery is a beautiful php image gallery with the focus on your images, trim
 | `storageDirName`           | Directory name used for cached/generated files                          | `storage`                                                   |
 | `imageCache`               | Enables or disables image caching (`true`, `false`)                         | `true`                                                      |
 | `cacheFileListMaxAge`      | Maximum age (in seconds) of cached file lists                           | `60`                                                        |
+| `coverFileName`            | Name of the custom cover image file                                     | `cover.jpg`                                                 |
 | `imageSizes.thumbnail`     | Size of the thumbnail images (width x height, or largest side)              | `400x400`                                                   |
 | `imageSizes.large`         | Maximum width for the large image version (width x height, or largest side) | `2000`                                                      |
 | `imageQuality`             | JPEG quality for generated images (1–100)                               | `85`                                                        |

--- a/src/config/site.example.php
+++ b/src/config/site.example.php
@@ -12,6 +12,7 @@
   "storageDirName": "storage",
   "imageCache": true,
   "cacheFileListMaxAge": 60,
+  "coverFileName": "cover.jpg",
   "imageSizes": {
     "thumbnail": "400x400",
     "large": "2000"

--- a/src/core/app/pages/album.php
+++ b/src/core/app/pages/album.php
@@ -12,7 +12,7 @@ $this->seo('metaDescription', $this->data('pageTitle').' - '.$this->seo('metaDes
 if(file_exists(IMAGES_DIR.DS.$this->album)){
   // load images and sub albums from album
   $addons->dispatch('beforeLoadGallery');
-  $this->gallery = new novafacile\novaGallery(IMAGES_DIR.DS.$this->album, $this->config('imageCache'), $this->config('cacheFileListMaxAge'), $this->config('useExifDate'), CACHE_DIR.DS.$this->album);
+  $this->gallery = new novafacile\novaGallery(IMAGES_DIR.DS.$this->album, $this->config('imageCache'), $this->config('cacheFileListMaxAge'), $this->config('useExifDate'), CACHE_DIR.DS.$this->album, 'filesCache.php', $this->config('coverFileName'));
   $parentPage = $this->gallery->parentAlbum($this->album);
   if($parentPage){
     $parentPage = 'album/'.$parentPage;

--- a/src/core/app/pages/home.php
+++ b/src/core/app/pages/home.php
@@ -7,7 +7,7 @@ $this->seo('metaDescription', $this->config('metaDescription'));
 
 // load images and albums from root dir
 $addons->dispatch('beforeLoadGallery');
-$this->gallery = new novafacile\novaGallery(IMAGES_DIR, $this->config('imageCache'), $this->config('cacheFileListMaxAge'), $this->config('useExifDate'), CACHE_DIR);
+$this->gallery = new novafacile\novaGallery(IMAGES_DIR, $this->config('imageCache'), $this->config('cacheFileListMaxAge'), $this->config('useExifDate'), CACHE_DIR, 'filesCache.php', $this->config('coverFileName'));
 $addons->dispatch('afterLoadGallery');
 
 // set data

--- a/src/core/vendor/novafacile/novaGallery.php
+++ b/src/core/vendor/novafacile/novaGallery.php
@@ -24,15 +24,17 @@ class novaGallery {
   protected bool $useExif = true;
   protected bool $allowSubAlbums = true;
   protected array $filesCache = [];
+  protected string $coverFileName = 'cover.jpg';
 
   // Todo: config via config array or object
-  function __construct(string $dir, bool $onlyWithImages = true, bool|int $maxCacheAge = 60, bool $useExif = true, bool|string $cacheDir = false, string $cacheFile = 'filesCache.php'){
+  function __construct(string $dir, bool $onlyWithImages = true, bool|int $maxCacheAge = 60, bool $useExif = true, bool|string $cacheDir = false, string $cacheFile = 'filesCache.php', string $coverFileName = 'cover.jpg'){
     $this->dir = $dir;
     $this->onlyWithImages = $onlyWithImages;
     $this->maxCacheAge = $maxCacheAge;
     $this->cacheDir = $cacheDir;
     $this->cacheFile = $cacheFile;
     $this->useExif = $useExif;
+    $this->coverFileName = $coverFileName;
 
     $cacheResult = false;
     if($this->maxCacheAge){
@@ -78,9 +80,27 @@ class novaGallery {
         );
     }
   }
+    
+    // Exclude the custom cover image file from the image list
+    $images = $this->excludeCoverImage($images, $dir);
+    
     return $this->fileList($images, true);
   }
 
+  /**
+   * Exclude the custom cover image file from the image list
+   * Case-insensitive matching for cover.jpg, Cover.jpg, COVER.JPG, etc.
+   */
+  protected function excludeCoverImage(array $images, string $dir) : array {
+    $coverPathLower = strtolower($dir . '/' . $this->coverFileName);
+    
+    // Filter images to exclude cover file (case-insensitive)
+    $filtered = array_filter($images, function($image) use ($coverPathLower) {
+      return strtolower($image) !== $coverPathLower;
+    });
+    
+    return $filtered;
+  }
 
   // create array of files or dirs without path & with last modification date
   protected function fileList(array $list, bool $withCaptureDate = false) : array {
@@ -241,7 +261,7 @@ class novaGallery {
   protected function removeEmptyAlbums(array $albums) : array {
     foreach ($albums as $album => $modDate) {
       if(!$this->hasImages($album) && $this->allowSubAlbums){
-        $subAlbum = new novaGallery($this->dir.'/'.$album, $this->onlyWithImages, $this->maxCacheAge, $this->useExif, $this->cacheDir.'/'.$album, $this->cacheFile);
+        $subAlbum = new novaGallery($this->dir.'/'.$album, $this->onlyWithImages, $this->maxCacheAge, $this->useExif, $this->cacheDir.'/'.$album, $this->cacheFile, $this->coverFileName);
         if(!$subAlbum->hasAlbums()){
           unset($albums[$album]);
         }
@@ -332,20 +352,34 @@ class novaGallery {
     return $this->order($this->images, $order);
   }
 
-
-
+  /**
+   * Return the cover image for a gallery or album
+   * If a custom cover file exists, it will be returned
+   * Otherwise, returns the first image based on the specified order
+   */
   public function coverImage(string|int $album, string $order = 'default') : string {
     $album = (string) $album;
-    if($this->hasImages($album)){
-      $images = $this->order($this->albums["$album"], $order);  
+    
+    // Determine the directory to check
+    $checkDir = $this->dir.'/'.$album;
+    
+    // Check if a custom cover file exists
+    if($this->hasCoverImage($checkDir)){
+      return $this->getCoverImageName();
+    }
+
+    // Otherwise, use default behavior
+    if($album !== '' && $this->hasImages($album)){
+      $images = $this->order($this->albums[$album], $order);  
       reset($images);
       return key($images);
     } 
+    
     if(!$this->allowSubAlbums){
       return false;
     }
 
-    $subGallery = new novaGallery($this->dir.'/'.$album, $this->onlyWithImages, $this->maxCacheAge, $this->useExif, $this->cacheDir.'/'.$album, $this->cacheFile);
+    $subGallery = new novaGallery($this->dir.'/'.$album, $this->onlyWithImages, $this->maxCacheAge, $this->useExif, $this->cacheDir.'/'.$album, $this->cacheFile, $this->coverFileName);
     if($subGallery->hasAlbums()){
       $albums = $subGallery->albums($order);
       $firstAlbum = array_key_first($albums);
@@ -358,6 +392,46 @@ class novaGallery {
     }
     // else return false
     return false;
+  }
+
+  /**
+   * Check if a custom cover image file exists in the directory
+   * Case-insensitive file name matching for cross-platform compatibility
+   */
+  protected function hasCoverImage(string $dir) : bool {
+    $coverPathLower = strtolower($dir . '/' . $this->coverFileName);
+    
+    // Get list of all image files in directory
+    if(defined('GLOB_BRACE')){
+      $imageOnly = '*.{[jJ][pP][gG],[jJ][pP][eE][gG],[pP][nN][gG],[gG][iI][fF],[wW][eE][bB][pP]}';
+      $allFiles = glob($dir.'/'.$imageOnly, GLOB_BRACE);
+    } else {
+      $extensions = ['jpg', 'jpeg', 'png', 'gif', 'webp'];  
+      $allFiles = [];  
+      foreach ($extensions as $ext) {  
+        $allFiles = array_merge(
+          $allFiles,  
+          glob($dir.'/*.'.$ext),  
+          glob($dir.'/*.'.strtoupper($ext)) 
+        );
+      }
+    }
+    
+    // Check if cover file exists
+    foreach($allFiles as $file) {
+      if(strtolower($file) === $coverPathLower) {
+        return true;
+      }
+    }
+    
+    return false;
+  }
+
+  /**
+   * Get the cover image file name
+   */
+  protected function getCoverImageName() : string {
+    return $this->coverFileName;
   }
 
   public function hasAlbums() : bool {


### PR DESCRIPTION
**What?**

Customize the cover image for each album.

**How?**

By placing a file named `cover.jpg` (by default) or your custom filename configured in `coverFileName` in the album directory. This image will be used as the album cover instead of the automatically generated preview.

**Why?**

- Use a specific image from the album
- Use a special image that will not be displayed in the album
- Any other need where the cover image must be set manually